### PR TITLE
ci: explicite which version is SDK or API

### DIFF
--- a/.github/scripts/release-check-duplicate.sh
+++ b/.github/scripts/release-check-duplicate.sh
@@ -20,7 +20,7 @@ if [ -z "$GH_TOKEN" ]; then
     exit 1
 fi
 
-result=$(curl -s -u LolUserName:$GH_TOKEN "https://api.github.com/repos/outscale/osc-sdk-go/pulls" | jq ".[] | select(.title == \"$new_sdk_version version\") | .title")
+result=$(curl -s -u LolUserName:$GH_TOKEN "https://api.github.com/repos/outscale/osc-sdk-go/pulls" | jq ".[] | select(.title == \"SDK v$new_sdk_version\") | .title")
 
 if [ ! -z "$result" ]; then
     echo "Pull request seems to alread exist, abort."

--- a/.github/scripts/release-pr.sh
+++ b/.github/scripts/release-pr.sh
@@ -17,7 +17,7 @@ if [ -z "$GH_TOKEN" ]; then
 fi
 
 # https://docs.github.com/en/free-pro-team@latest/rest/reference/pulls#create-a-pull-request
-result=$(curl -s -X POST -u LolUserName:$GH_TOKEN -d "{\"head\":\"$branch_name\",\"base\":\"v$major\",\"title\":\"$new_sdk_version version\",\"body\":\"Automatic build of $new_sdk_version version based on $osc_api_version\"}" "https://api.github.com/repos/outscale/osc-sdk-go/pulls")
+result=$(curl -s -X POST -u LolUserName:$GH_TOKEN -d "{\"head\":\"$branch_name\",\"base\":\"v$major\",\"title\":\"SDK v$new_sdk_version\",\"body\":\"Automatic build of SDK v$new_sdk_version version based on Outscale API v$osc_api_version\"}" "https://api.github.com/repos/outscale/osc-sdk-go/pulls")
 
 errors=$(echo $result | jq .errors)
 


### PR DESCRIPTION
When automatically opening a MR when a new version is out, the message is ambigous as we don't know if provided versions are the SDK version or the API version.

Signed-off-by: Jérôme Jutteau <jerome.jutteau@outscale.com>