### PR TITLE
🧑‍💻 dx: add profile.New, rename/add options to profile.NewFromStandardConfiguration

### DIFF
--- a/examples/keypair_test.go
+++ b/examples/keypair_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestKeypair(t *testing.T) {
-	userProfile, err := profile.NewProfileFromStandardConfiguration("", "")
+	userProfile, err := profile.New()
 	if err != nil {
 		panic(err)
 	}
@@ -23,7 +23,7 @@ func TestKeypair(t *testing.T) {
 
 	keypairName := "osc-sdk-go-example"
 	faux := false
-	keypair, err := client.CreateKeypair(ctx, osc.CreateKeypairRequest{
+	resp, err := client.CreateKeypair(ctx, osc.CreateKeypairRequest{
 		DryRun:      &faux,
 		KeypairName: keypairName,
 	})
@@ -31,10 +31,10 @@ func TestKeypair(t *testing.T) {
 		panic(err)
 	}
 
-	t.Logf("Keypair created: %v", *keypair)
+	t.Logf("Keypair created: %s", *resp.Keypair.KeypairId)
 
 	_, err = client.DeleteKeypair(ctx, osc.DeleteKeypairRequest{
-		KeypairId: keypair.Keypair.KeypairId,
+		KeypairId: resp.Keypair.KeypairId,
 	})
 	if err != nil {
 		panic(err)

--- a/examples/project_test.go
+++ b/examples/project_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestProject(t *testing.T) {
-	userProfile, err := profile.NewProfileFromStandardConfiguration("", "")
+	userProfile, err := profile.New()
 	if err != nil {
 		panic(err)
 	}

--- a/examples/vms_test.go
+++ b/examples/vms_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestReadVms(t *testing.T) {
-	userProfile, err := profile.NewProfileFromStandardConfiguration("", "")
+	userProfile, err := profile.New()
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -40,6 +40,8 @@ type Profile struct {
 	Endpoints         Endpoint `json:"endpoints"`
 }
 
+type Option func(*Profile) error
+
 func newConfigFile() *configFile {
 	return &configFile{
 		profiles: make(map[string]Profile),
@@ -108,28 +110,32 @@ func LoadProfileFromEnv() Profile {
 	return profile
 }
 
-func NewProfileFromStandardConfiguration(profile, path string) (*Profile, error) {
+// New loads the profile from the environment or a profile file.
+// The profile file name is fetched from the OSC_CONFIG_FILE env var, or `~/.osc/config.json` if not set.
+// The profile name is fetched from OSC_PROFILE, or `default` if not set.
+func New(opts ...Option) (*Profile, error) {
+	var profile string
+	if value, present := os.LookupEnv("OSC_PROFILE"); present {
+		profile = value
+	} else {
+		profile = defaultProfile
+	}
+
+	var path string
+	if value, present := os.LookupEnv("OSC_CONFIG_FILE"); present {
+		path = value
+	} else {
+		path, _ = defaultConfigPath()
+	}
+	return NewFrom(profile, path, opts...)
+}
+
+// NewFrom loads the profile from the environment or a profile file.
+func NewFrom(profile, path string, opts ...Option) (*Profile, error) {
 	// 1. Load profile from environment
 	mergedProfile := LoadProfileFromEnv()
 
-	// 2. Load additional config from environment
-	if profile == "" {
-		if value, present := os.LookupEnv("OSC_PROFILE"); present {
-			profile = value
-		} else {
-			profile = defaultProfile
-		}
-	}
-
-	if path == "" {
-		if value, present := os.LookupEnv("OSC_CONFIG_FILE"); present {
-			path = value
-		} else {
-			path, _ = defaultConfigPath()
-		}
-	}
-
-	// 3. Load profile for config file
+	// 2. Load profile for config file and merge
 	configFile, err := loadConfigFile(path)
 	if err == nil {
 		if fileprofile, ok := configFile.profiles[profile]; ok {
@@ -142,7 +148,15 @@ func NewProfileFromStandardConfiguration(profile, path string) (*Profile, error)
 		}
 	}
 
-	// 4. Load default
+	// 3. Apply options
+	for _, opt := range opts {
+		err := opt(&mergedProfile)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// 4. Set defaults
 	if mergedProfile.Protocol == "" {
 		mergedProfile.Protocol = "https"
 	}


### PR DESCRIPTION
## Description

Breaking change: replace `profile.NewProfileFromStandardConfiguration(string, string)` by `profile.New(...Option)` and `profile.NewFrom(string, string, ...Option)`

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context

