### PR TITLE
:rocket: chore: add GitHub release config and sync-labels workflow

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,56 @@
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+    authors:
+      - github-actions[bot]
+
+  categories:
+    - title: 💥 Breaking
+      labels:
+        - breaking-change
+    - title: ✨ Added
+      labels:
+        - kind/feature
+    - title: 🛠️ Changed / Refactoring
+      labels:
+        - kind/refactoring
+        - kind/other
+    - title: 📝 Documentation
+      labels:
+        - kind/documentation
+    - title: ⚰️ Deprecated
+      labels:
+        - kind/deprecation
+    - title: 🗑️ Removed
+      labels:
+        - kind/cleanup
+    - title: 🐛 Fixed
+      labels:
+        - kind/bug
+    - title: 🔒 Security
+      labels:
+        - security
+    - title: 📦 Dependency updates
+      labels:
+        - dependencies
+    - title: 🌱 Others
+      labels:
+        - "*"
+
+templates:
+  title: "Release v$RESOLVED_VERSION"
+  body: |
+    ## 📦 Overview
+    This release brings new features, bug fixes, and improvements.
+
+    ## 📝 Changelog
+    $CHANGES
+
+    ## 🔧 Upgrade notes
+    - Review **Breaking Changes** carefully.
+    - Follow migration steps if applicable.
+
+    ## 👥 Contributors
+    Thanks to everyone who contributed:
+    $CONTRIBUTORS

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,16 @@
+name: Sync labels
+on:
+  workflow_dispatch:
+
+permissions:
+  issues: write  # needed to edit labels
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: EndBug/label-sync@v2
+        with:
+          config-file: 'https://raw.githubusercontent.com/outscale/.github/main/labels.yml'
+          # delete-other-labels: false   # set to true for strict sync
+          # dry-run: false               # set to true to preview changes


### PR DESCRIPTION
## Description

This PR adds standardized GitHub configuration files:

- \`.github/release.yml\`: Release configuration with changelog automation and categorization
- \`.github/workflows/sync-labels.yml\`: Workflow to sync repository labels from central configuration

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [x] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [x] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)