### PR TITLE
✨ feat(profile): custom profile loading order, config file management

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,12 +8,14 @@ require (
 	github.com/getkin/kin-openapi v0.133.0
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/oapi-codegen/runtime v1.1.2
+	github.com/stretchr/testify v1.11.1
 	go.uber.org/ratelimit v0.3.1
 )
 
 require (
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/benbjohnson/clock v1.3.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
@@ -26,6 +28,7 @@ require (
 	github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 // indirect
 	github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/speakeasy-api/jsonpath v0.6.0 // indirect
 	github.com/speakeasy-api/openapi-overlay v0.10.2 // indirect
 	github.com/vmware-labs/yaml-jsonpath v0.3.2 // indirect

--- a/pkg/profile/endpoint.go
+++ b/pkg/profile/endpoint.go
@@ -6,13 +6,13 @@ import (
 )
 
 type Endpoint struct {
-	API        string `json:"api"`
-	OKS        string `json:"oks"`
-	LBU        string `json:"lbu"`
-	OOS        string `json:"oos"`
-	FCU        string `json:"fcu"`
-	EIM        string `json:"eim"`
-	DirectLink string `json:"direct_link"`
+	API        string `json:"api,omitempty"`
+	OKS        string `json:"oks,omitempty"`
+	LBU        string `json:"lbu,omitempty"`
+	OOS        string `json:"oos,omitempty"`
+	FCU        string `json:"fcu,omitempty"`
+	EIM        string `json:"eim,omitempty"`
+	DirectLink string `json:"direct_link,omitempty"`
 }
 
 func getDefaultEndpointTemplate(service OscService) (string, error) {

--- a/pkg/profile/file.go
+++ b/pkg/profile/file.go
@@ -1,0 +1,109 @@
+package profile
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+)
+
+var ErrNoDefaultProfile = errors.New("no default profile found")
+
+type ConfigFile struct {
+	Path     string
+	Profiles map[string]Profile
+}
+
+func (cf *ConfigFile) DefaultProfile() (string, Profile, error) {
+	for name, p := range cf.Profiles {
+		if p.Default {
+			return name, p, nil
+		}
+	}
+	if _, found := cf.Profiles[DefaultProfile]; !found {
+		return "", Profile{}, ErrNoDefaultProfile
+	}
+	return DefaultProfile, cf.Profiles[DefaultProfile], nil
+}
+
+func (cf *ConfigFile) Profile(profile string) (Profile, error) {
+	if profile == "" {
+		_, p, err := cf.DefaultProfile()
+		return p, err
+	}
+
+	if _, found := cf.Profiles[profile]; !found {
+		return Profile{}, fmt.Errorf("profile %q does not exist", profile)
+	}
+	return cf.Profiles[profile], nil
+}
+
+func LoadConfigFile(path string) (*ConfigFile, error) {
+	if path == "" {
+		var err error
+		path, err = DefaultConfigPath()
+		if err != nil {
+			return nil, fmt.Errorf("unable to locate config file: %w", err)
+		}
+	}
+
+	configJSON, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("unable to load config file: %w", err)
+	}
+
+	cf := &ConfigFile{
+		Path:     path,
+		Profiles: make(map[string]Profile),
+	}
+	if err := json.Unmarshal(configJSON, &cf.Profiles); err != nil {
+		return nil, fmt.Errorf("unable to load config file: %w", err)
+	}
+	return cf, nil
+}
+
+func (cf *ConfigFile) Save() error {
+	tmpFile := cf.Path + ".tmp"
+	fd, err := os.OpenFile(tmpFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return fmt.Errorf("unable to save config file: %w", err)
+	}
+	enc := json.NewEncoder(fd)
+	enc.SetIndent("", "  ")
+	err = enc.Encode(cf.Profiles)
+	if err != nil {
+		_ = fd.Close()
+	} else {
+		err = fd.Close()
+	}
+	if err == nil {
+		saveFile := cf.Path + ".saved"
+		err = os.Rename(cf.Path, saveFile)
+		if errors.Is(err, fs.ErrNotExist) {
+			err = nil
+		}
+	}
+	if err == nil {
+		err = os.Rename(tmpFile, cf.Path)
+	}
+	if err != nil {
+		_ = os.Remove(tmpFile)
+		return fmt.Errorf("unable to save config file: %w", err)
+	}
+	return nil
+}
+
+func (cf *ConfigFile) SetDefault(profile string) error {
+	name, def, err := cf.DefaultProfile()
+	if err == nil && def.Default {
+		def.Default = false
+		cf.Profiles[name] = def
+	}
+	if p, found := cf.Profiles[profile]; found {
+		p.Default = true
+		cf.Profiles[profile] = p
+		return nil
+	}
+	return fmt.Errorf("profile %q does not exist", profile)
+}

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -5,8 +5,6 @@
 package profile
 
 import (
-	"encoding/json"
-	"errors"
 	"os"
 	"path"
 	"strings"
@@ -18,35 +16,30 @@ const (
 	DefaultProfile = "default"
 )
 
-type configFile struct {
-	profiles map[string]Profile
+type Profile struct {
+	Default           bool     `json:"default,omitempty"`
+	AccessKey         string   `json:"access_key,omitempty"`
+	SecretKey         string   `json:"secret_key,omitempty"`
+	AccessKeyV2       string   `json:"access_key_v2,omitempty"`
+	SecretKeyV2       string   `json:"secret_key_v2,omitempty"`
+	IAMV2Services     []string `json:"iam_v2_services,omitempty"`
+	X509ClientCert    string   `json:"x509_client_cert,omitempty"`
+	X509ClientCertB64 string   `json:"x509_client_cert_b64,omitempty"`
+	X509ClientKey     string   `json:"x509_client_key,omitempty"`
+	X509ClientKeyB64  string   `json:"x509_client_key_b64,omitempty"`
+	TlsSkipVerify     bool     `json:"tls_skip_verify,omitempty"`
+	Login             string   `json:"login,omitempty"`
+	Password          string   `json:"password,omitempty"`
+	Protocol          string   `json:"protocol,omitempty"`
+	Region            string   `json:"region,omitempty"`
+	Endpoints         Endpoint `json:"endpoints,omitempty"`
 }
 
-type Profile struct {
-	AccessKey         string   `json:"access_key"`
-	SecretKey         string   `json:"secret_key"`
-	AccessKeyV2       string   `json:"access_key_v2"`
-	SecretKeyV2       string   `json:"secret_key_v2"`
-	IAMV2Services     []string `json:"iam_v2_services"`
-	X509ClientCert    string   `json:"x509_client_cert"`
-	X509ClientCertB64 string   `json:"x509_client_cert_b64"`
-	X509ClientKey     string   `json:"x509_client_key"`
-	X509ClientKeyB64  string   `json:"x509_client_key_b64"`
-	TlsSkipVerify     bool     `json:"tls_skip_verify"`
-	Login             string
-	Password          string
-	Protocol          string   `json:"protocol"`
-	Region            string   `json:"region"`
-	Endpoints         Endpoint `json:"endpoints"`
+func (p *Profile) IsSet() bool {
+	return (p.AccessKey != "" && p.SecretKey != "") || (p.AccessKeyV2 != "" && p.SecretKeyV2 != "")
 }
 
 type Option func(*Profile) error
-
-func newConfigFile() *configFile {
-	return &configFile{
-		profiles: make(map[string]Profile),
-	}
-}
 
 func DefaultConfigPath() (string, error) {
 	home, err := os.UserHomeDir()
@@ -56,120 +49,121 @@ func DefaultConfigPath() (string, error) {
 	return path.Join(home, ".osc", "config.json"), nil
 }
 
-func loadConfigFile(path string) (*configFile, error) {
-	if path == "" {
-		return nil, errors.New("no path provided")
-	}
+// FromFile is an option that loads env from a file.
+func FromFile(profile, path string) Option {
+	return func(p *Profile) error {
+		if p.IsSet() {
+			return nil
+		}
 
-	configJSON, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
+		if profile == "" {
+			profile = os.Getenv("OSC_PROFILE")
+		}
+		if path == "" {
+			path = os.Getenv("OSC_CONFIG_FILE")
+		}
+		configFile, err := LoadConfigFile(path)
+		switch {
+		// no path/profile given, do not fail if default file is missing
+		case path == "" && profile == "" && err != nil:
+			return nil
+		case err != nil:
+			return err
+		}
+		cfp, err := configFile.Profile(profile)
+		switch {
+		// no path/profile given, do not fail if default profile is missing
+		case path == "" && profile == "" && err != nil:
+			return nil
+		case err != nil:
+			return err
+		}
+		*p = cfp
+		return nil
 	}
-
-	configFile := newConfigFile()
-	if err := json.Unmarshal(configJSON, &configFile.profiles); err != nil {
-		return nil, err
-	}
-
-	return configFile, nil
 }
 
 func getenvBool(key string) bool {
-	env := os.Getenv(key)
-	return env == "yes" || env == "Yes" || env == "true" || env == "True"
+	env := strings.ToLower(os.Getenv(key))
+	return env == "yes" || env == "true"
 }
 
-func LoadProfileFromEnv() Profile {
-	var profile Profile
+// FromEnv is an option that loads a profile from env vars.
+func FromEnv() Option {
+	return func(p *Profile) error {
+		if p.IsSet() {
+			return nil
+		}
 
-	profile.AccessKey = os.Getenv("OSC_ACCESS_KEY")
-	profile.SecretKey = os.Getenv("OSC_SECRET_KEY")
-	profile.AccessKeyV2 = os.Getenv("OSC_ACCESS_KEY_V2")
-	profile.SecretKeyV2 = os.Getenv("OSC_SECRET_KEY_V2")
-	profile.X509ClientCert = os.Getenv("OSC_X509_CLIENT_CERT")
-	profile.X509ClientCertB64 = os.Getenv("OSC_X509_CLIENT_CERT_B64")
-	profile.X509ClientKey = os.Getenv("OSC_X509_CLIENT_KEY")
-	profile.X509ClientKeyB64 = os.Getenv("OSC_X509_CLIENT_KEY_B64")
-	profile.TlsSkipVerify = getenvBool("OSC_TLS_SKIP_VERIFY")
-	profile.Login = os.Getenv("OSC_LOGIN")
-	profile.Password = os.Getenv("OSC_PASSWORD")
-	profile.Protocol = os.Getenv("OSC_PROTOCOL")
-	profile.Region = os.Getenv("OSC_REGION")
-	profile.Endpoints.API = os.Getenv("OSC_ENDPOINT_API")
-	profile.Endpoints.OKS = os.Getenv("OSC_ENDPOINT_OKS")
-	profile.Endpoints.LBU = os.Getenv("OSC_ENDPOINT_LBU")
-	profile.Endpoints.OOS = os.Getenv("OSC_ENDPOINT_OOS")
-	profile.Endpoints.FCU = os.Getenv("OSC_ENDPOINT_FCU")
-	profile.Endpoints.EIM = os.Getenv("OSC_ENDPOINT_EIM")
-	profile.Endpoints.DirectLink = os.Getenv("OSC_ENDPOINT_DIRECT_LINK")
+		p.AccessKey = os.Getenv("OSC_ACCESS_KEY")
+		p.SecretKey = os.Getenv("OSC_SECRET_KEY")
+		p.AccessKeyV2 = os.Getenv("OSC_ACCESS_KEY_V2")
+		p.SecretKeyV2 = os.Getenv("OSC_SECRET_KEY_V2")
+		p.X509ClientCert = os.Getenv("OSC_X509_CLIENT_CERT")
+		p.X509ClientCertB64 = os.Getenv("OSC_X509_CLIENT_CERT_B64")
+		p.X509ClientKey = os.Getenv("OSC_X509_CLIENT_KEY")
+		p.X509ClientKeyB64 = os.Getenv("OSC_X509_CLIENT_KEY_B64")
+		p.TlsSkipVerify = getenvBool("OSC_TLS_SKIP_VERIFY")
+		p.Login = os.Getenv("OSC_LOGIN")
+		p.Password = os.Getenv("OSC_PASSWORD")
+		p.Protocol = os.Getenv("OSC_PROTOCOL")
+		p.Region = os.Getenv("OSC_REGION")
+		p.Endpoints.API = os.Getenv("OSC_ENDPOINT_API")
+		p.Endpoints.OKS = os.Getenv("OSC_ENDPOINT_OKS")
+		p.Endpoints.LBU = os.Getenv("OSC_ENDPOINT_LBU")
+		p.Endpoints.OOS = os.Getenv("OSC_ENDPOINT_OOS")
+		p.Endpoints.FCU = os.Getenv("OSC_ENDPOINT_FCU")
+		p.Endpoints.EIM = os.Getenv("OSC_ENDPOINT_EIM")
+		p.Endpoints.DirectLink = os.Getenv("OSC_ENDPOINT_DIRECT_LINK")
 
-	if iamV2Services, ok := os.LookupEnv("OSC_IAM_V2_SERVICES"); ok {
-		profile.IAMV2Services = strings.Split(iamV2Services, ",")
+		if iamV2Services, ok := os.LookupEnv("OSC_IAM_V2_SERVICES"); ok {
+			p.IAMV2Services = strings.Split(iamV2Services, ",")
+		}
+
+		return nil
 	}
+}
 
-	return profile
+// MergeWith is a profile option that merges any previously loaded profile with
+// another.
+func MergeWith(opt Option) Option {
+	return func(p *Profile) error {
+		var other Profile
+		err := opt(&other)
+		if err != nil {
+			return err
+		}
+		return mergo.Merge(p, other)
+	}
 }
 
 // New loads the profile from the environment or a profile file.
 // The profile file name is fetched from the OSC_CONFIG_FILE env var, or `~/.osc/config.json` if not set.
 // The profile name is fetched from OSC_PROFILE, or `default` if not set.
 func New(opts ...Option) (*Profile, error) {
-	return NewFrom("", "", opts...)
+	if len(opts) == 0 {
+		opts = []Option{FromEnv(), MergeWith(FromFile("", ""))}
+	}
+	var p Profile
+	for _, opt := range opts {
+		err := opt(&p)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if p.Protocol == "" {
+		p.Protocol = "https"
+	}
+
+	if p.Region == "" {
+		p.Region = "eu-west-2"
+	}
+	return &p, nil
 }
 
 // NewFrom loads the profile from the environment or a profile file.
 // If empty, the profile file name is fetched from the OSC_CONFIG_FILE env var, or `~/.osc/config.json` if not set.
 // If empty, the profile name is fetched from OSC_PROFILE, or `default` if not set.
-func NewFrom(profile, path string, opts ...Option) (*Profile, error) {
-	// 1. Load profile from environment
-	mergedProfile := LoadProfileFromEnv()
-
-	// 2. Load additional config from environment
-	if profile == "" {
-		if value, present := os.LookupEnv("OSC_PROFILE"); present {
-			profile = value
-		} else {
-			profile = DefaultProfile
-		}
-	}
-
-	if path == "" {
-		if value, present := os.LookupEnv("OSC_CONFIG_FILE"); present {
-			path = value
-		} else {
-			path, _ = DefaultConfigPath()
-		}
-	}
-
-	// 3. Load profile for config file and merge
-	configFile, err := loadConfigFile(path)
-	if err == nil {
-		if fileprofile, ok := configFile.profiles[profile]; ok {
-			err := mergo.Merge(&mergedProfile, fileprofile)
-			if err != nil {
-				return nil, err
-			}
-		} else if profile != DefaultProfile {
-			return nil, errors.New("specified profile not found")
-		}
-	}
-
-	// 4. Apply options
-	for _, opt := range opts {
-		err := opt(&mergedProfile)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// 5. Set defaults
-	if mergedProfile.Protocol == "" {
-		mergedProfile.Protocol = "https"
-	}
-
-	if mergedProfile.Region == "" {
-		mergedProfile.Region = "eu-west-2"
-	}
-
-	return &mergedProfile, nil
+func NewFrom(profile, path string) (*Profile, error) {
+	return New(FromEnv(), MergeWith(FromFile(profile, path)))
 }

--- a/pkg/profile/profile_test.go
+++ b/pkg/profile/profile_test.go
@@ -1,0 +1,166 @@
+package profile_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/outscale/osc-sdk-go/v3/pkg/profile"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFromEnv(t *testing.T) {
+	t.Run("profile is loaded from env", func(t *testing.T) {
+		t.Setenv("OSC_ACCESS_KEY", "foo")
+		t.Setenv("OSC_SECRET_KEY", "bar")
+		p := profile.Profile{}
+		err := profile.FromEnv()(&p)
+		require.NoError(t, err)
+		assert.True(t, p.IsSet())
+		assert.Equal(t, "foo", p.AccessKey)
+		assert.Equal(t, "bar", p.SecretKey)
+	})
+	t.Run("env is ignored if already loaded", func(t *testing.T) {
+		t.Setenv("OSC_ACCESS_KEY", "foo")
+		t.Setenv("OSC_SECRET_KEY", "bar")
+		p := profile.Profile{
+			AccessKey: "bar",
+			SecretKey: "baz",
+		}
+		err := profile.FromEnv()(&p)
+		require.NoError(t, err)
+		assert.True(t, p.IsSet())
+		assert.Equal(t, "bar", p.AccessKey)
+		assert.Equal(t, "baz", p.SecretKey)
+	})
+}
+
+func TestFromFile(t *testing.T) {
+	t.Run("the default profile is loaded", func(t *testing.T) {
+		cf := newConfigFile(t)
+		p := profile.Profile{}
+		err := profile.FromFile("", cf.Path)(&p)
+		require.NoError(t, err)
+		assert.Equal(t, "defaultak", p.AccessKey)
+		assert.Equal(t, "defaultsk", p.SecretKey)
+	})
+	t.Run("a profile is loaded", func(t *testing.T) {
+		cf := newConfigFile(t)
+		p := profile.Profile{}
+		err := profile.FromFile("foo", cf.Path)(&p)
+		require.NoError(t, err)
+		assert.Equal(t, "fooak", p.AccessKey)
+		assert.Equal(t, "foosk", p.SecretKey)
+	})
+	t.Run("a custom default is loaded", func(t *testing.T) {
+		cf := newConfigFile(t)
+		err := cf.SetDefault("foo")
+		require.NoError(t, err)
+		err = cf.Save()
+		require.NoError(t, err)
+		p := profile.Profile{}
+		err = profile.FromFile("", cf.Path)(&p)
+		require.NoError(t, err)
+		assert.Equal(t, "fooak", p.AccessKey)
+		assert.Equal(t, "foosk", p.SecretKey)
+	})
+}
+
+func TestNewFrom(t *testing.T) {
+	cf := newConfigFile(t)
+	t.Run("env is loaded first", func(t *testing.T) {
+		t.Setenv("OSC_ACCESS_KEY", "foo")
+		t.Setenv("OSC_SECRET_KEY", "bar")
+		p, err := profile.NewFrom("", cf.Path)
+		require.NoError(t, err)
+		assert.Equal(t, "foo", p.AccessKey)
+		assert.Equal(t, "bar", p.SecretKey)
+	})
+	t.Run("env is loaded first, even if profile is set", func(t *testing.T) {
+		t.Setenv("OSC_ACCESS_KEY", "foo")
+		t.Setenv("OSC_SECRET_KEY", "bar")
+		p, err := profile.NewFrom("foo", cf.Path)
+		require.NoError(t, err)
+		assert.Equal(t, "foo", p.AccessKey)
+		assert.Equal(t, "bar", p.SecretKey)
+	})
+	t.Run("file is used if env is empty", func(t *testing.T) {
+		t.Setenv("OSC_ACCESS_KEY", "")
+		t.Setenv("OSC_SECRET_KEY", "")
+		p, err := profile.NewFrom("", cf.Path)
+		require.NoError(t, err)
+		assert.Equal(t, "defaultak", p.AccessKey)
+		assert.Equal(t, "defaultsk", p.SecretKey)
+	})
+	t.Run("OSC_CONFIG_FILE can define the config file path", func(t *testing.T) {
+		t.Setenv("OSC_ACCESS_KEY", "")
+		t.Setenv("OSC_SECRET_KEY", "")
+		t.Setenv("OSC_CONFIG_FILE", cf.Path)
+		p, err := profile.NewFrom("", "")
+		require.NoError(t, err)
+		assert.Equal(t, "defaultak", p.AccessKey)
+		assert.Equal(t, "defaultsk", p.SecretKey)
+	})
+	t.Run("OSC_PROFILE can define the profile path", func(t *testing.T) {
+		t.Setenv("OSC_ACCESS_KEY", "")
+		t.Setenv("OSC_SECRET_KEY", "")
+		t.Setenv("OSC_PROFILE", "foo")
+		p, err := profile.NewFrom("", cf.Path)
+		require.NoError(t, err)
+		assert.Equal(t, "fooak", p.AccessKey)
+		assert.Equal(t, "foosk", p.SecretKey)
+	})
+	t.Run("file is merged with env", func(t *testing.T) {
+		t.Setenv("OSC_ACCESS_KEY", "foo")
+		t.Setenv("OSC_SECRET_KEY", "bar")
+		p, err := profile.NewFrom("", cf.Path)
+		require.NoError(t, err)
+		assert.Equal(t, "foo", p.AccessKey)
+		assert.Equal(t, "bar", p.SecretKey)
+		assert.Equal(t, "defaultakv2", p.AccessKeyV2)
+		assert.Equal(t, "defaultskv2", p.SecretKeyV2)
+	})
+	t.Run("NewFrom does not fail if no credentials are found", func(t *testing.T) {
+		t.Setenv("OSC_ACCESS_KEY", "")
+		t.Setenv("OSC_SECRET_KEY", "")
+		p, err := profile.NewFrom("", "")
+		require.NoError(t, err)
+		assert.Equal(t, "", p.AccessKey)
+		assert.Equal(t, "", p.SecretKey)
+	})
+	t.Run("NewFrom fails if a config file was requested and not found", func(t *testing.T) {
+		t.Setenv("OSC_ACCESS_KEY", "")
+		t.Setenv("OSC_SECRET_KEY", "")
+		_, err := profile.NewFrom("", "/does/not/exist")
+		require.Error(t, err)
+	})
+	t.Run("NewFrom fails if a profile was requested and not found", func(t *testing.T) {
+		t.Setenv("OSC_ACCESS_KEY", "")
+		t.Setenv("OSC_SECRET_KEY", "")
+		_, err := profile.NewFrom("does not exist", cf.Path)
+		require.Error(t, err)
+	})
+}
+
+func newConfigFile(t *testing.T) *profile.ConfigFile {
+	path := filepath.Join(t.TempDir(), "config.json")
+
+	cf := profile.ConfigFile{
+		Path: path,
+		Profiles: map[string]profile.Profile{
+			profile.DefaultProfile: profile.Profile{
+				AccessKey:   "defaultak",
+				SecretKey:   "defaultsk",
+				AccessKeyV2: "defaultakv2",
+				SecretKeyV2: "defaultskv2",
+			},
+			"foo": profile.Profile{
+				AccessKey: "fooak",
+				SecretKey: "foosk",
+			},
+		},
+	}
+	err := cf.Save()
+	require.NoError(t, err)
+	return &cf
+}


### PR DESCRIPTION
## Description

There was no way to force the SDK to use a profile file if env var were set.

This PRs updates `profile.New` with options that allow the user to specify where he wants the profile to come from.
`profile.NewFrom` handles env/file as before.

The PR also adds functions to manage a config file.

⚠️ Behaviour change ⚠️

`profile.New([something], [something])` did not previously fail, but fails now.

The rationale is that if the user specifically asks for a profile or a config file, we should fail if it was not found.

`profile.New("", "")` does not fail if not config file exists or if it has no default profile.

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [x] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
