### PR TITLE
♻️ refacto(time): iso8601.Time now outputs using the input format (year, month, date or datetime)

### DIFF
--- a/pkg/iso8601/README.md
+++ b/pkg/iso8601/README.md
@@ -1,3 +1,3 @@
 # ISO8601
 
-this is a vendored vertion of [ISO8601](https://github.com/relvacode/iso8601).
+This is based on the [github.com/relvacode/iso8601](https://github.com/relvacode/iso8601) package.

--- a/pkg/iso8601/iso8601.go
+++ b/pkg/iso8601/iso8601.go
@@ -97,13 +97,22 @@ func ParseISOZone(inp []byte) (*time.Location, error) {
 
 // Parse parses an ISO8601 compliant date-time byte slice into a time.Time object.
 // If any component of an input date-time is not within the expected range then an *iso8601.RangeError is returned.
+//
+// Deprecated: consider using ParseString.
 func Parse(inp []byte) (time.Time, error) {
 	return ParseInLocation(inp, time.UTC)
 }
 
 // ParseInLocation parses an ISO8601 compliant date-time byte slice into a time.Time object.
 // If the input does not have timezone information, it will use the given location.
+//
+// Deprecated: consider using ParseString/ParseInLocationString.
 func ParseInLocation(inp []byte, loc *time.Location) (time.Time, error) {
+	t, _, err := parseInLocation(inp, loc)
+	return t, err
+}
+
+func parseInLocation(inp []byte, loc *time.Location) (time.Time, uint, error) {
 	var (
 		Y         uint
 		M         uint
@@ -138,7 +147,7 @@ parse:
 				case month:
 					M = c
 				default:
-					return time.Time{}, newUnexpectedCharacterError(inp[i])
+					return time.Time{}, 0, newUnexpectedCharacterError(inp[i])
 				}
 				p++
 				c = 0
@@ -163,18 +172,18 @@ parse:
 			case millisecond:
 				fraction = int(c)
 			default:
-				return time.Time{}, newUnexpectedCharacterError(inp[i])
+				return time.Time{}, 0, newUnexpectedCharacterError(inp[i])
 			}
 			c = 0
 			var err error
 			loc, err = ParseISOZone(inp[i:])
 			if err != nil {
-				return time.Time{}, err
+				return time.Time{}, 0, err
 			}
 			break parse
 		case 'T', ' ':
 			if p != day {
-				return time.Time{}, newUnexpectedCharacterError(inp[i])
+				return time.Time{}, 0, newUnexpectedCharacterError(inp[i])
 			}
 			d = c
 			c = 0
@@ -188,19 +197,19 @@ parse:
 			case second:
 				m = c
 			default:
-				return time.Time{}, newUnexpectedCharacterError(inp[i])
+				return time.Time{}, 0, newUnexpectedCharacterError(inp[i])
 			}
 			c = 0
 			p++
 		case '.':
 			if p != second {
-				return time.Time{}, newUnexpectedCharacterError(inp[i])
+				return time.Time{}, 0, newUnexpectedCharacterError(inp[i])
 			}
 			s = c
 			c = 0
 			p++
 		default:
-			return time.Time{}, newUnexpectedCharacterError(inp[i])
+			return time.Time{}, 0, newUnexpectedCharacterError(inp[i])
 		}
 	}
 
@@ -230,7 +239,7 @@ parse:
 
 	// Get the seconds fraction as nanoseconds
 	if fraction < 0 || 1e9 <= fraction {
-		return time.Time{}, ErrPrecision
+		return time.Time{}, 0, ErrPrecision
 	}
 	scale := 10 - nfraction
 	for i := 0; i < scale; i++ {
@@ -239,7 +248,7 @@ parse:
 
 	switch {
 	case M < 1 || M > 12: // Month 1-12
-		return time.Time{}, &RangeError{
+		return time.Time{}, 0, &RangeError{
 			Value:   string(inp),
 			Element: "month",
 			Given:   int(M),
@@ -247,7 +256,7 @@ parse:
 			Max:     12,
 		}
 	case d < 1 || int(d) > daysIn(time.Month(M), int(Y)): // Day 1-daysIn(month, year)
-		return time.Time{}, &RangeError{
+		return time.Time{}, 0, &RangeError{
 			Value:   string(inp),
 			Element: "day",
 			Given:   int(d),
@@ -255,7 +264,7 @@ parse:
 			Max:     daysIn(time.Month(M), int(Y)),
 		}
 	case h > 23: // Hour 0-23
-		return time.Time{}, &RangeError{
+		return time.Time{}, 0, &RangeError{
 			Value:   string(inp),
 			Element: "hour",
 			Given:   int(h),
@@ -263,7 +272,7 @@ parse:
 			Max:     23,
 		}
 	case m > 59: // Minute 0-59
-		return time.Time{}, &RangeError{
+		return time.Time{}, 0, &RangeError{
 			Value:   string(inp),
 			Element: "minute",
 			Given:   int(m),
@@ -271,7 +280,7 @@ parse:
 			Max:     59,
 		}
 	case s > 59: // Second 0-59
-		return time.Time{}, &RangeError{
+		return time.Time{}, 0, &RangeError{
 			Value:   string(inp),
 			Element: "second",
 			Given:   int(s),
@@ -280,5 +289,5 @@ parse:
 		}
 	}
 
-	return time.Date(int(Y), time.Month(M), int(d), int(h), int(m), int(s), fraction, loc), nil
+	return time.Date(int(Y), time.Month(M), int(d), int(h), int(m), int(s), fraction, loc), p, nil
 }

--- a/pkg/iso8601/json.go
+++ b/pkg/iso8601/json.go
@@ -1,23 +1,15 @@
 package iso8601
 
-import (
-	"fmt"
-	"time"
-)
+import "encoding/json"
 
-type Time struct {
-	time.Time
-}
-
-func (t *Time) MarshalJSON() ([]byte, error) {
-	// Let's try to aim for a format that is RFC3339 and ISO8601 compatible
-	s := fmt.Sprintf("\"%s\"", t.In(time.UTC).Format("2006-01-02T15:04:05Z"))
-	return []byte(s), nil
+func (t Time) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + t.String() + `"`), nil
 }
 
 func (t *Time) UnmarshalJSON(data []byte) error {
 	// try to be stupid
 	if err := t.Time.UnmarshalJSON(data); err == nil {
+		t.Format = DateTime
 		return nil
 	}
 
@@ -33,11 +25,14 @@ func (t *Time) UnmarshalJSON(data []byte) error {
 		return ErrNotString
 	}
 
-	tmp, err := ParseInLocation(data, time.UTC)
+	tmp, err := ParseString(string(data))
 	if err != nil {
 		return err
 	}
 
-	t.Time = tmp
+	*t = tmp
 	return nil
 }
+
+var _ json.Marshaler = Time{}
+var _ json.Unmarshaler = (*Time)(nil)

--- a/pkg/iso8601/time.go
+++ b/pkg/iso8601/time.go
@@ -2,6 +2,120 @@ package iso8601
 
 import "time"
 
+type Format int
+
+const (
+	DateTime Format = iota
+	DateYear
+	DateMonth
+	DateDay
+)
+
+type Time struct {
+	Format Format
+	time.Time
+}
+
+func (t Time) String() string {
+	switch t.Format {
+	case DateYear:
+		return t.Time.In(time.UTC).Format("2006")
+	case DateMonth:
+		return t.Time.In(time.UTC).Format("2006-01")
+	case DateDay:
+		return t.Time.In(time.UTC).Format("2006-01-02")
+	default:
+		// Let's try to aim for a format that is RFC3339 and ISO8601 compatible
+		return t.Time.In(time.UTC).Format("2006-01-02T15:04:05.999Z")
+	}
+}
+
+func Now() Time {
+	return Time{Format: DateTime, Time: time.Now()}
+}
+
+func Date(year int, month time.Month, day, hour, min, sec, nsec int, loc *time.Location) Time {
+	return Time{Format: DateTime, Time: time.Date(year, month, day, hour, min, sec, nsec, time.UTC)}
+}
+
+func Day(year int, month time.Month, day int) Time {
+	return Time{Format: DateDay, Time: time.Date(year, month, day, 0, 0, 0, 0, time.UTC)}
+}
+
+func Month(year int, month time.Month) Time {
+	return Time{Format: DateMonth, Time: time.Date(year, month, 1, 0, 0, 0, 0, time.UTC)}
+}
+
+func Year(year int) Time {
+	return Time{Format: DateYear, Time: time.Date(year, 1, 1, 0, 0, 0, 0, time.UTC)}
+}
+
+func (t Time) Add(d time.Duration) Time {
+	return Time{Format: t.Format, Time: t.Time.Add(d)}
+}
+
+func (t Time) AddDate(y, m, d int) Time {
+	return Time{Format: t.Format, Time: t.Time.AddDate(y, m, d)}
+}
+
+// At returns the date time at a specific time of day.
+func (t Time) At(hour, min, sec, nsec int) Time {
+	return Time{Format: DateTime, Time: time.Date(t.Year(), t.Month(), t.Day(), hour, min, sec, nsec, time.UTC)}
+}
+
+// MonthStart returns the first day of the month
+func (t Time) MonthStart() Time {
+	return Time{Format: DateDay, Time: time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, time.UTC)}
+}
+
+// AtStart returns the first time of the month
+func (t Time) AtStart() Time {
+	return t.MonthStart().At(0, 0, 0, 0)
+}
+
+// MonthEnd returns the last day of the month
+func (t Time) MonthEnd() Time {
+	return t.MonthStart().AddDate(0, 1, -1)
+}
+
+// AtEnd returns the last time of the month with a millisecond precision
+func (t Time) AtEnd() Time {
+	return t.MonthStart().AddDate(0, 1, 0).At(0, 0, 0, int(-time.Millisecond))
+}
+
+// Equal checks that two Time structs are equal (same Format, both Time are equal)
+func (t Time) Equal(t2 Time) bool {
+	if t.Format != t2.Format {
+		return false
+	}
+	return t.Time.Equal(t2.Time)
+}
+
+// ParseString parses a year/month/day or datetime string, expecting a time.UTC location.
+func ParseString(s string) (Time, error) {
+	return ParseInLocationString(s, time.UTC)
+}
+
+// ParseInLocationString parses a year/month/day or datetime string into a Time.
+func ParseInLocationString(s string, loc *time.Location) (Time, error) {
+	t, precision, err := parseInLocation([]byte(s), loc)
+	if err != nil {
+		return Time{}, err
+	}
+	var f Format
+	switch precision {
+	case year:
+		f = DateYear
+	case month:
+		f = DateMonth
+	case day:
+		f = DateDay
+	default:
+		f = DateTime
+	}
+	return Time{Format: f, Time: t}, nil
+}
+
 // The following is copied from the Go standard library to implement date range validation logic
 // equivalent to the behaviour of Go's time.Parse.
 

--- a/pkg/iso8601/time_test.go
+++ b/pkg/iso8601/time_test.go
@@ -1,0 +1,137 @@
+package iso8601_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/outscale/osc-sdk-go/v3/pkg/iso8601"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	tcs = []struct {
+		json string
+		str  string
+		t    iso8601.Time
+		err  bool
+	}{
+		{
+			json: `"2026"`,
+			str:  "2026",
+			t:    iso8601.Time{Format: iso8601.DateYear, Time: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)},
+		},
+		{
+			json: `"2026-02"`,
+			str:  "2026-02",
+			t:    iso8601.Time{Format: iso8601.DateMonth, Time: time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)},
+		},
+		{
+			json: `"2026-09-02"`,
+			str:  "2026-09-02",
+			t:    iso8601.Time{Format: iso8601.DateDay, Time: time.Date(2026, 9, 2, 0, 0, 0, 0, time.UTC)},
+		},
+		{
+			json: `"2026-06-04T09:32:44Z"`,
+			str:  "2026-06-04T09:32:44Z",
+			t:    iso8601.Time{Format: iso8601.DateTime, Time: time.Date(2026, 6, 4, 9, 32, 44, 0, time.UTC)},
+		},
+		{
+			json: `"2026-06-04T09:32:44+0000"`,
+			str:  "2026-06-04T09:32:44Z",
+			t:    iso8601.Time{Format: iso8601.DateTime, Time: time.Date(2026, 6, 4, 9, 32, 44, 0, time.UTC)},
+		},
+		{
+			json: `"2026-06-04T09:32:44+0100"`,
+			str:  "2026-06-04T08:32:44Z",
+			t:    iso8601.Time{Format: iso8601.DateTime, Time: time.Date(2026, 6, 4, 8, 32, 44, 0, time.UTC)},
+		},
+		{
+			json: `"2026-06-04T09:32:44.642Z"`,
+			str:  "2026-06-04T09:32:44.642Z",
+			t:    iso8601.Time{Format: iso8601.DateTime, Time: time.Date(2026, 6, 4, 9, 32, 44, int(642*time.Millisecond), time.UTC)},
+		},
+	}
+)
+
+func TestParseString(t *testing.T) {
+	for _, tc := range tcs {
+		ts, err := iso8601.ParseString(tc.str)
+		if tc.err {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+		}
+		assert.Truef(t, tc.t.Equal(ts), "source: %s, parsed: %s", tc.str, ts.String())
+	}
+}
+
+func TestString(t *testing.T) {
+	for _, tc := range tcs {
+		str := tc.t.String()
+		assert.Equal(t, tc.str, str)
+	}
+}
+
+func TestUnmarshal(t *testing.T) {
+	for _, tc := range tcs {
+		var ts iso8601.Time
+		err := json.Unmarshal([]byte(tc.json), &ts)
+		require.NoError(t, err)
+		assert.Truef(t, tc.t.Equal(ts), "source: %s, unmarshaled: %s", tc.json, ts.String())
+	}
+}
+
+func TestMarshal(t *testing.T) {
+	for _, tc := range tcs {
+		buf, err := json.Marshal(tc.t)
+		require.NoError(t, err)
+		var ts iso8601.Time
+		err = json.Unmarshal(buf, &ts)
+		require.NoError(t, err)
+		assert.Truef(t, tc.t.Equal(ts), "source: %s, json %s, unmarshaled: %s", tc.t.String(), string(buf), ts.String())
+	}
+}
+
+func TestAt(t *testing.T) {
+	d := iso8601.Day(2026, 2, 15)
+	assert.Equal(t, "2026-02-15", d.String())
+	at := d.At(23, 42, 15, int(999*time.Millisecond))
+	assert.Equal(t, "2026-02-15T23:42:15.999Z", at.String())
+}
+
+func TestStart(t *testing.T) {
+	t.Run("MonthStart/MonthEnd work with standard years", func(t *testing.T) {
+		d := iso8601.Day(2026, 2, 15)
+		assert.Equal(t, "2026-02-15", d.String())
+		start := d.MonthStart()
+		assert.Equal(t, "2026-02-01", start.String())
+		end := d.MonthEnd()
+		assert.Equal(t, "2026-02-28", end.String())
+	})
+	t.Run("MonthStart/MonthEnd work with leap years", func(t *testing.T) {
+		d := iso8601.Day(2028, 2, 15)
+		assert.Equal(t, "2028-02-15", d.String())
+		start := d.MonthStart()
+		assert.Equal(t, "2028-02-01", start.String())
+		end := d.MonthEnd()
+		assert.Equal(t, "2028-02-29", end.String())
+	})
+	t.Run("AtStart/AtEnd work with standard years", func(t *testing.T) {
+		d := iso8601.Day(2026, 2, 15)
+		assert.Equal(t, "2026-02-15", d.String())
+		start := d.AtStart()
+		assert.Equal(t, "2026-02-01T00:00:00Z", start.String())
+		end := d.AtEnd()
+		assert.Equal(t, "2026-02-28T23:59:59.999Z", end.String())
+	})
+	t.Run("AtStart/AtEnd work with leap years", func(t *testing.T) {
+		d := iso8601.Day(2028, 2, 15)
+		assert.Equal(t, "2028-02-15", d.String())
+		start := d.AtStart()
+		assert.Equal(t, "2028-02-01T00:00:00Z", start.String())
+		end := d.AtEnd()
+		assert.Equal(t, "2028-02-29T23:59:59.999Z", end.String())
+	})
+}


### PR DESCRIPTION
## Description

This PR adds a Format attribute to iso8601.Time.

Format is set during parsing to reflect the input format, and output uses the specified format.

It also:
* outputs ms (ms were previously dropped in the output)
* adds many helpers to manage times (Now, Add, AddDate, Equal)

It would be probably better to have separate structs for Date and DateTime, but this would be a large breaking change, and add a significant amount of complexity, as some APIs accept both date and datetime input in some fields.

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [x] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

ms output:
```shell
octl iaasapilog list --query-date-after -1d
```
output should use the same format as input:
```shell
octl iaas consumptionaccount list --from-date 2025-02-01 --to-date 2025-10-06 -v
```

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
