### PR TITLE
🐛 fix(profile): creating profile file directory

### DIFF
--- a/pkg/profile/file.go
+++ b/pkg/profile/file.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path/filepath"
 )
 
 var ErrNoDefaultProfile = errors.New("no default profile found")
@@ -64,6 +65,13 @@ func LoadConfigFile(path string) (*ConfigFile, error) {
 }
 
 func (cf *ConfigFile) Save() error {
+	dir := filepath.Dir(cf.Path)
+	if _, err := os.Stat(dir); errors.Is(err, fs.ErrNotExist) {
+		err := os.MkdirAll(dir, 0700)
+		if err != nil {
+			return fmt.Errorf("unable to save config file: %w", err)
+		}
+	}
 	tmpFile := cf.Path + ".tmp"
 	fd, err := os.OpenFile(tmpFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {

--- a/pkg/profile/file_test.go
+++ b/pkg/profile/file_test.go
@@ -1,0 +1,41 @@
+package profile_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/outscale/osc-sdk-go/v3/pkg/profile"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigFile_Save(t *testing.T) {
+	t.Run("A new profile file can be created in an existing directory", func(t *testing.T) {
+		cf := &profile.ConfigFile{
+			Path: filepath.Join(t.TempDir(), "existing.json"),
+			Profiles: map[string]profile.Profile{
+				"foo": {Default: true},
+			},
+		}
+		err := cf.Save()
+		require.NoError(t, err)
+
+		scf, err := profile.LoadConfigFile(cf.Path)
+		require.NoError(t, err)
+		assert.Equal(t, cf.Profiles, scf.Profiles)
+	})
+	t.Run("A new profile file can be created in a missing directory", func(t *testing.T) {
+		cf := &profile.ConfigFile{
+			Path: filepath.Join(t.TempDir(), "foo", "bar", "missing.json"),
+			Profiles: map[string]profile.Profile{
+				"foo": {Default: true},
+			},
+		}
+		err := cf.Save()
+		require.NoError(t, err)
+
+		scf, err := profile.LoadConfigFile(cf.Path)
+		require.NoError(t, err)
+		assert.Equal(t, cf.Profiles, scf.Profiles)
+	})
+}


### PR DESCRIPTION
## Description

Saving a profile file fails if the directory is missing. This PRs creates the profile directory (and its parents) if missing

## Type of Change

Please check the relevant option(s):

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [x] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
