### PR TITLE
✨ feat(oos): option to retry until timeout

### DIFF
--- a/pkg/oos/options.go
+++ b/pkg/oos/options.go
@@ -1,0 +1,44 @@
+package oos
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/smithy-go/middleware"
+)
+
+var _ middleware.InitializeMiddleware = (*retryTimeoutMiddleware)(nil)
+
+type retryTimeoutMiddleware struct {
+	timeout time.Duration
+}
+
+func (*retryTimeoutMiddleware) ID() string {
+	return "OOSRetryTimeout"
+}
+
+func (m *retryTimeoutMiddleware) HandleInitialize(
+	ctx context.Context,
+	in middleware.InitializeInput,
+	next middleware.InitializeHandler,
+) (middleware.InitializeOutput, middleware.Metadata, error) {
+	ctx, cancel := context.WithTimeout(ctx, m.timeout)
+	defer cancel()
+
+	return next.HandleInitialize(ctx, in)
+}
+
+func WithRetryTimeout(timeout time.Duration) func(*s3.Options) {
+	return func(options *s3.Options) {
+		options.APIOptions = append(
+			options.APIOptions,
+			func(stack *middleware.Stack) error {
+				return stack.Initialize.Add(
+					&retryTimeoutMiddleware{timeout: timeout},
+					middleware.Before,
+				)
+			},
+		)
+	}
+}


### PR DESCRIPTION
## Description

- Add an OOS specific option to retry until a go `time.Duration` timeout, similarly to the options.WithRetryTimeout

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [X] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [X] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [X] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [X] I have added tests or explained why they are not needed
* [X] I have updated relevant documentation (README, examples, etc.)
* [X] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [X] My commits include appropriate [Gitmoji](https://gitmoji.dev/)
